### PR TITLE
Add TERM_PROGRAM(_VERSION) to textual-web.

### DIFF
--- a/src/textual_web/app_session.py
+++ b/src/textual_web/app_session.py
@@ -14,6 +14,7 @@ from time import monotonic
 from datetime import timedelta
 from pathlib import Path
 
+from importlib_metadata import version
 
 import rich.repr
 
@@ -132,6 +133,8 @@ class AppSession(Session):
         environment["TEXTUAL_DRIVER"] = "textual.drivers.web_driver:WebDriver"
         environment["TEXTUAL_FPS"] = "60"
         environment["TEXTUAL_COLOR_SYSTEM"] = "truecolor"
+        environment["TERM_PROGRAM"] = "textual-web"
+        environment["TERM_PROGRAM_VERSION"] = version("textual-web")
         environment["COLUMNS"] = str(width)
         environment["ROWS"] = str(height)
         if self.devtools:

--- a/src/textual_web/terminal_session.py
+++ b/src/textual_web/terminal_session.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from collections import deque
 import asyncio
 import array
 import fcntl
@@ -11,7 +9,7 @@ import pty
 import signal
 import termios
 
-
+from importlib_metadata import version
 import rich.repr
 
 from .poller import Poller
@@ -19,7 +17,6 @@ from .session import Session, SessionConnector
 from .types import Meta, SessionID
 
 log = logging.getLogger("textual-web")
-
 
 @rich.repr.auto
 class TerminalSession(Session):
@@ -48,6 +45,8 @@ class TerminalSession(Session):
         self.pid = pid
         self.master_fd = master_fd
         if pid == pty.CHILD:
+            os.environ["TERM_PROGRAM"] = "textual-web"
+            os.environ["TERM_PROGRAM_VERSION"] = version("textual-web")
             argv = [self.command]
             try:
                 os.execlp(argv[0], *argv)  ## Exits the app


### PR DESCRIPTION
This sets the environment variables TERM_PROGRAM and TERM_PROGRAM_VERSION to 'textual-web' and to the version of textual-web, respectively, when running apps or opening terminals with textual-web.

Fixes https://github.com/Textualize/textual/issues/3269